### PR TITLE
Add optional --output argument to make_hlainfo.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ python train.py --ref REFERENCE (.bgl.phased/.bim) --sample SAMPLE (.bim) --mo
 | `--sample`    | Sample SNP data of the MHC region (.bim format).             | Yes      | None      |
 | `--model`     | Model configuration (.model.json format).                    | Yes      | None      |
 | `--hla`       | HLA information of the reference data (.hla.json format).    | Yes      | None      |
-| `--model-dir` | Directory for saving trained models.                         | No       | "model"   |
+| `--model-dir` | Directory for saving trained models.                         | No       | {BASE\_DIR}/model   |
 | `--num-epoch` | Number of epochs to train.                                   | No       | 100       |
 | `--patience`  | Patience for early-stopping. If you prefer no early-stopping, specify the same value as `--num-epoch`. | No       | 16        |
 | `--val-split` | Ratio of splitting data for validation.                      | No       | 0.1       |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ cd ./DEEP-HLA
   | ------------- | ------------------------------------------------------------ | -------- | --------- |
   | `--ref`       | HLA reference data (.bim format).                            | Yes      | None      |
   | `--max-digit` | Maximum resolution of alleles typed in the HLA reference data ("2-digit", "4-digit", or "6-digit"). | No       | "4-digit" |
-  
+  | `--output`    | Output filename for HLA information JSON file                | No       | {BASE\_DIR}/{REFERENCE}.hla.json |
+
   ##### Outputs
   
   - {REFERENCE}.hla.json

--- a/make_hlainfo.py
+++ b/make_hlainfo.py
@@ -59,11 +59,16 @@ def make_hlainfo(args):
             for d_i in range(len(digit_list)):
                 digit = digit_list[d_i]
                 hla_info[hla][digit] = [i for i in allele_list if len(i.split('_')[-1])==2*(d_i+1) or len(i.split('_')[-1])==2*(d_i+1)+1]
-            
+
             if len(hla_info[hla][digit]) == 0:
                 print('Warning: {0} alleles of {1} are not typed.'.format(digit, hla))
 
-    with open(os.path.join(BASE_DIR, args.ref + '.hla.json'), 'w') as f:
+    if args.output:
+        output_fname = args.output
+    else:
+        output_fname = os.path.join(BASE_DIR, args.ref + '.hla.json')
+
+    with open(output_fname, 'w') as f:
         json.dump(hla_info, f)
 
     print('Done.')
@@ -75,6 +80,7 @@ def main():
                         help='HLA reference data (.bgl.phased or .haps, and .bim format).', dest='ref')
     parser.add_argument('--max-digit', default='4-digit', choices=['2-digit', '4-digit', '6-digit'], required=False,
                         help='Maximum resolution of classical alleles typed in the reference panel.', dest='max_digit')
+    parser.add_argument('--output', required=False, help='Output filename for HLA information JSON file.', dest='output')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
When running in a container environment, the default path of `{BASE_DIR}/<path>` may be read-only so this option allows an alternate output path.