### PR TITLE
Allow remaining scripts to specify absolute path for --model-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ python impute.py --sample SAMPLE (.bgl.phased (.haps)/.bim/.fam) --model MODEL
 | `--phased-type` | File format of sample phased file ("bgl" or "haps").         | No       | "bgl"     |
 | `--model`       | Model configuration (.model.json and .bim format).           | Yes      | None      |
 | `--hla`         | HLA information of the reference data (.hla.json format).    | Yes      | None      |
-| `--model-dir`   | Directory where trained models are saved.                    | No       | "model"   |
+| `--model-dir`   | Directory where trained models are saved.                    | No       | {BASE\_DIR}/model   |
 | `--out`         | Prefix of output files.                                      | Yes      | None      |
 | `--max-digit`   | Maximum resolution of alleles to impute ("2-digit", "4-digit", or "6-digit"). | No       | "4-digit" |
 | `--mc-dropout`  | Whether to calculate uncertainty by Monte Carlo dropout (True or False). | No       | False     |

--- a/impute.align_by_name.py
+++ b/impute.align_by_name.py
@@ -31,7 +31,7 @@ def impute(args):
     sample_bim = pd.read_table(args.sample + '.bim', sep='\t|\s+', names=['chr', 'id', 'dist', 'pos', 'a1', 'a2'], header=None, engine='python')
     sample_fam = pd.read_table(args.sample + '.fam', sep='\t|\s+', names=['fid', 'iid', 'fat', 'mot', 'sex', 'phe'], header=None, engine='python')
     model_dir = args.model_dir
-    model_bim = pd.read_table(os.path.join(BASE_DIR, model_dir, 'model.bim'), sep='\t|\s+', names=['chr', 'id', 'dist', 'pos', 'a1', 'a2'], header=None, engine='python')
+    model_bim = pd.read_table(os.path.join(model_dir, 'model.bim'), sep='\t|\s+', names=['chr', 'id', 'dist', 'pos', 'a1', 'a2'], header=None, engine='python')
     with open(args.hla + '.hla.json', 'r') as f:
         hla_info = json.load(f)
     if args.max_digit == '2-digit':
@@ -131,11 +131,11 @@ def impute(args):
 
                 # Load models
                 model = {'shared': SharedNet(model_config[g], ed_index-st_index, input_collapse=False)}
-                model['shared'].load_state_dict(torch.load(os.path.join(BASE_DIR, model_dir, '{}_{}_shared_model.pickle'.format(g, digit))))
+                model['shared'].load_state_dict(torch.load(os.path.join(model_dir, '{}_{}_shared_model.pickle'.format(g, digit))))
                 for hla in hla_list:
                     if not allele_cnts[hla] == 1:
                         model[hla] = EachNet(model_config[g], allele_cnts[hla])
-                        model[hla].load_state_dict(torch.load(os.path.join(BASE_DIR, model_dir, '{}_{}_{}_model.pickle'.format(g, digit, hla))))
+                        model[hla].load_state_dict(torch.load(os.path.join(model_dir, '{}_{}_{}_model.pickle'.format(g, digit, hla))))
                 for m in model:
                     model[m] = model[m].float()
                     model[m].eval()
@@ -221,7 +221,7 @@ def main():
     parser.add_argument('--model', required=True, help='Model configuration (.model.json format).', dest='model')
     parser.add_argument('--phased-type', default='bgl', choices=['bgl', 'haps'], required=False, help='File format of sample phased file ("bgl", "haps").', dest='phased_type')
     parser.add_argument('--hla', required=True, help='HLA information of the reference data (.hla.json format).', dest='hla')
-    parser.add_argument('--model-dir', default='model', required=False, help='Directory for saving trained models.', dest='model_dir')
+    parser.add_argument('--model-dir', default=os.path.join(BASE_DIR, 'model'), required=False, help='Directory for saving trained models.', dest='model_dir')
     parser.add_argument('--out', required=True, help='Prefix of result file', dest='out')
     parser.add_argument('--max-digit', default='4-digit', choices=['2-digit', '4-digit', '6-digit'], required=False, help='Maximum resolution of alleles to impute.', dest='max_digit')
     parser.add_argument('--mc-dropout', default=False, type=bool, choices=[True, False], required=False, help='Whether to calculate uncertainty by Monte Carlo dropout.', dest='mc_dropout')

--- a/impute.py
+++ b/impute.py
@@ -31,7 +31,7 @@ def impute(args):
     sample_bim = pd.read_table(args.sample + '.bim', sep='\t|\s+', names=['chr', 'id', 'dist', 'pos', 'a1', 'a2'], header=None, engine='python')
     sample_fam = pd.read_table(args.sample + '.fam', sep='\t|\s+', names=['fid', 'iid', 'fat', 'mot', 'sex', 'phe'], header=None, engine='python')
     model_dir = args.model_dir
-    model_bim = pd.read_table(os.path.join(BASE_DIR, model_dir, 'model.bim'), sep='\t|\s+', names=['chr', 'id', 'dist', 'pos', 'a1', 'a2'], header=None, engine='python')
+    model_bim = pd.read_table(os.path.join(model_dir, 'model.bim'), sep='\t|\s+', names=['chr', 'id', 'dist', 'pos', 'a1', 'a2'], header=None, engine='python')
     with open(args.hla + '.hla.json', 'r') as f:
         hla_info = json.load(f)
     if args.max_digit == '2-digit':
@@ -131,11 +131,11 @@ def impute(args):
 
                 # Load models
                 model = {'shared': SharedNet(model_config[g], ed_index-st_index, input_collapse=False)}
-                model['shared'].load_state_dict(torch.load(os.path.join(BASE_DIR, model_dir, '{}_{}_shared_model.pickle'.format(g, digit))))
+                model['shared'].load_state_dict(torch.load(os.path.join(model_dir, '{}_{}_shared_model.pickle'.format(g, digit))))
                 for hla in hla_list:
                     if not allele_cnts[hla] == 1:
                         model[hla] = EachNet(model_config[g], allele_cnts[hla])
-                        model[hla].load_state_dict(torch.load(os.path.join(BASE_DIR, model_dir, '{}_{}_{}_model.pickle'.format(g, digit, hla))))
+                        model[hla].load_state_dict(torch.load(os.path.join(model_dir, '{}_{}_{}_model.pickle'.format(g, digit, hla))))
                 for m in model:
                     model[m] = model[m].float()
                     model[m].eval()
@@ -221,7 +221,7 @@ def main():
     parser.add_argument('--model', required=True, help='Model configuration (.model.json format).', dest='model')
     parser.add_argument('--phased-type', default='bgl', choices=['bgl', 'haps'], required=False, help='File format of sample phased file ("bgl", "haps").', dest='phased_type')
     parser.add_argument('--hla', required=True, help='HLA information of the reference data (.hla.json format).', dest='hla')
-    parser.add_argument('--model-dir', default='model', required=False, help='Directory for saving trained models.', dest='model_dir')
+    parser.add_argument('--model-dir', default=os.path.join(BASE_DIR, 'model'), required=False, help='Directory for saving trained models.', dest='model_dir')
     parser.add_argument('--out', required=True, help='Prefix of result file', dest='out')
     parser.add_argument('--max-digit', default='4-digit', choices=['2-digit', '4-digit', '6-digit'], required=False, help='Maximum resolution of alleles to impute.', dest='max_digit')
     parser.add_argument('--mc-dropout', default=False, type=bool, choices=[True, False], required=False, help='Whether to calculate uncertainty by Monte Carlo dropout.', dest='mc_dropout')

--- a/train.align_by_name.py
+++ b/train.align_by_name.py
@@ -189,12 +189,12 @@ def train(args):
     ref_concord_phased = ref_phased.iloc[np.where(concord_snp)[0]]
     model_bim = ref_bim.iloc[np.where(concord_snp)[0]]
 
-    if not os.path.exists(os.path.join(BASE_DIR, model_dir)):
-        os.mkdir(os.path.join(BASE_DIR, model_dir))
+    if not os.path.exists(model_dir):
+        os.mkdir(model_dir)
     else:
         print('Warning: Directory for saving models already exists.')
 
-    model_bim.to_csv(os.path.join(BASE_DIR, model_dir, 'model.bim'), sep='\t', header=False, index=False)
+    model_bim.to_csv(os.path.join(model_dir, 'model.bim'), sep='\t', header=False, index=False)
 
     # Encode reference SNP data
     snp_encoded = np.zeros((2*num_ref, num_concord, 2))
@@ -267,7 +267,7 @@ def train(args):
             # Transfer parameters of shared net from those of upper digit
             if not digit == '2-digit':
                 try:
-                    model['shared'].load_state_dict(torch.load(os.path.join(BASE_DIR, model_dir, '{}_{}_shared_model.pickle'.format(g, digit_list[digit_list.index(digit)-1]))))
+                    model['shared'].load_state_dict(torch.load(os.path.join(model_dir, '{}_{}_shared_model.pickle'.format(g, digit_list[digit_list.index(digit)-1]))))
                     logger.log('Transferred parameters from shared net of upper digit at {} level.'.format(digit))
                 except FileNotFoundError:
                     logger.log('Shared net of upper digit not found at {} level.'.format(digit))
@@ -300,17 +300,17 @@ def train(args):
                 logger.log('Average validation accuracy: {}'.format(ave_val_acc))
                 # Save the current model if the current model is equal or better than the best one
                 if ave_val_acc >= best_ave_val_acc:
-                    torch.save(model['shared'].state_dict(), os.path.join(BASE_DIR, model_dir, '{}_{}_epoch{}_shared_model.pickle'.format(g, digit, epoch)))
+                    torch.save(model['shared'].state_dict(), os.path.join(model_dir, '{}_{}_epoch{}_shared_model.pickle'.format(g, digit, epoch)))
                     t = 0
                     for hla in hla_list:
                         if not allele_cnts[hla] == 1:
-                            torch.save(model[t].state_dict(), os.path.join(BASE_DIR, model_dir, '{}_{}_epoch{}_{}_model.pickle'.format(g, digit, epoch, hla)))
+                            torch.save(model[t].state_dict(), os.path.join(model_dir, '{}_{}_epoch{}_{}_model.pickle'.format(g, digit, epoch, hla)))
                             t += 1
                     if not epoch == 1:
-                        os.remove(os.path.join(BASE_DIR, model_dir, '{}_{}_epoch{}_shared_model.pickle'.format(g, digit, best_epoch)))
+                        os.remove(os.path.join(model_dir, '{}_{}_epoch{}_shared_model.pickle'.format(g, digit, best_epoch)))
                         for hla in hla_list:
                             if not allele_cnts[hla] == 1:
-                                os.remove(os.path.join(BASE_DIR, model_dir, '{}_{}_epoch{}_{}_model.pickle'.format(g, digit, best_epoch, hla)))
+                                os.remove(os.path.join(model_dir, '{}_{}_epoch{}_{}_model.pickle'.format(g, digit, best_epoch, hla)))
                     best_epoch = epoch
                     if ave_val_acc > best_ave_val_acc:
                         best_ave_val_acc = ave_val_acc
@@ -327,20 +327,20 @@ def train(args):
             logger.log('The best model is at epoch {}.'.format(best_epoch))
 
             # Rename models
-            os.rename(os.path.join(BASE_DIR, model_dir, '{}_{}_epoch{}_shared_model.pickle'.format(g, digit, best_epoch)), 
-                      os.path.join(BASE_DIR, model_dir, '{}_{}_shared_model.pickle'.format(g, digit)))
+            os.rename(os.path.join(model_dir, '{}_{}_epoch{}_shared_model.pickle'.format(g, digit, best_epoch)), 
+                      os.path.join(model_dir, '{}_{}_shared_model.pickle'.format(g, digit)))
             for hla in hla_list:
                 if not allele_cnts[hla] == 1:
-                    os.rename(os.path.join(BASE_DIR, model_dir, '{}_{}_epoch{}_{}_model.pickle'.format(g, digit, best_epoch, hla)), 
-                              os.path.join(BASE_DIR, model_dir, '{}_{}_{}_model.pickle'.format(g, digit, hla)))
+                    os.rename(os.path.join(model_dir, '{}_{}_epoch{}_{}_model.pickle'.format(g, digit, best_epoch, hla)), 
+                              os.path.join(model_dir, '{}_{}_{}_model.pickle'.format(g, digit, hla)))
 
             # Load the best models
-            model['shared'].load_state_dict(torch.load(os.path.join(BASE_DIR, model_dir, '{}_{}_shared_model.pickle'.format(g, digit))))
+            model['shared'].load_state_dict(torch.load(os.path.join(model_dir, '{}_{}_shared_model.pickle'.format(g, digit))))
             t = 0
             for hla in hla_list:
                 if not allele_cnts[hla] == 1:
                     model[t].load_state_dict(
-                        torch.load(os.path.join(BASE_DIR, model_dir, '{}_{}_{}_model.pickle'.format(g, digit, hla))))
+                        torch.load(os.path.join(model_dir, '{}_{}_{}_model.pickle'.format(g, digit, hla))))
                     t += 1
             for m in model:
                 model[m] = model[m].float()
@@ -349,7 +349,7 @@ def train(args):
             best_val_acc = test_model(val_loader, hla_list, allele_cnts, num_task, model, metric, 'best_val')
             result_best_val.loc[hla_list, digit] = best_val_acc
 
-    result_best_val.to_csv(os.path.join(BASE_DIR, model_dir, 'best_val.txt'), header=True, index=True, sep='\t')
+    result_best_val.to_csv(os.path.join(model_dir, 'best_val.txt'), header=True, index=True, sep='\t')
 
     print('The processes have been finished at {}.'.format(time.ctime()))
 
@@ -360,7 +360,7 @@ def main():
     parser.add_argument('--sample', required=True, help='Sample SNP data (.bim format).', dest='sample')
     parser.add_argument('--model', required=True, help='Model configuration (.model.json format).', dest='model')
     parser.add_argument('--hla', required=True, help='HLA information of the reference data (.hla.json format).', dest='hla')
-    parser.add_argument('--model-dir', default='model', required=False, help='Directory for saving trained models.', dest='model_dir')
+    parser.add_argument('--model-dir', default=os.path.join(BASE_DIR, 'model'), required=False, help='Directory for saving trained models.', dest='model_dir')
     parser.add_argument('--num-epoch', default=100, type=int, required=False, help='Number of epochs to train.', dest='num_epoch')
     parser.add_argument('--patience', default=8, type=int, required=False, help='Patience for early-stopping.', dest='patience')
     parser.add_argument('--val-split', default=0.05, type=float, required=False, help='Ratio of splitting data for validation.', dest='val_split')


### PR DESCRIPTION
Moved `os.path.join(BASE_DIR, model_dir, ...)` code to a default value of `os.path.join(BASE_DIR, 'model')` for the `--model-dir` option so that absolute paths may be specified.